### PR TITLE
add exit to builtins

### DIFF
--- a/examples/exit.py
+++ b/examples/exit.py
@@ -1,11 +1,9 @@
 
-import sys
-
 from httpout import __server__
 
 print('Hello, ', end='')
 
 if __server__['QUERY_STRING']:
-    sys.exit(__server__['QUERY_STRING'] + '!\n')
+    exit(__server__['QUERY_STRING'] + '!\n')
 
-sys.exit(0)
+exit(0)

--- a/httpout/__init__.py
+++ b/httpout/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2024 nggit
 
-__version__ = '0.0.61'
+__version__ = '0.0.62'
 __all__ = ('HTTPOut',)
 
 from .httpout import HTTPOut  # noqa: E402

--- a/httpout/httpout.py
+++ b/httpout/httpout.py
@@ -148,6 +148,7 @@ class HTTPOut:
 
         builtins.__import__ = ho_import
         builtins.__globals__ = worker['__globals__']
+        builtins.exit = sys.exit
 
         g.wait = wait
         g.caches = {}


### PR DESCRIPTION
Before:
```python
import sys

if True:
    sys.exit()
```

After:
```python
if True:
    exit()
```
Although `exit` is almost always available in regular Python, this change is to ensure it is always there.
